### PR TITLE
Minor Fixes for DayZ Patches

### DIFF
--- a/SchanaModAutorun/Mission/mission/missiongameplay.c
+++ b/SchanaModAutorun/Mission/mission/missiongameplay.c
@@ -13,6 +13,8 @@ modded class MissionGameplay extends MissionBase
         m_SchanaAutorunInterruptInputs.Insert("UAMoveRight");
         m_SchanaAutorunInterruptInputs.Insert("UAFire");
         m_SchanaAutorunInterruptInputs.Insert("UATempRaiseWeapon");
+        m_SchanaAutorunInterruptInputs.Insert("UALeanLeft");
+        m_SchanaAutorunInterruptInputs.Insert("UALeanRight");
     }
 
     protected bool SchanaCheckInput(string inputName)

--- a/SchanaModAutorun/Mission/mission/missiongameplay.c
+++ b/SchanaModAutorun/Mission/mission/missiongameplay.c
@@ -72,7 +72,7 @@ modded class MissionGameplay extends MissionBase
 
     protected int SchanaAutorunGetUpdatedSpeed(PlayerBase player)
     {
-        if(player.GetStaminaHandler().GetStamina() <= 0)
+        if(player && (!player.CanSprint() || player.GetStaminaHandler().GetStamina() <= 0))
         {
             return DayZPlayerConstants.MOVEMENTIDX_RUN;
         }


### PR DESCRIPTION
Adjust speed back down if leg is broken Also allows mods that override the can sprint function to prevent sprinting
Interrupts auto run if the player leans as per 1.16 preventing leaning while sprinting.
